### PR TITLE
feat: eslint 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     docker:
       - image: cimg/node:lts
-    working_directory: ~/app
+    working_directory: ~/eslint-plugin-airtight
     steps:
       - checkout
       - run:
@@ -19,7 +19,7 @@ jobs:
   release:
     docker:
       - image: cimg/node:lts
-    working_directory: ~/app
+    working_directory: ~/eslint-plugin-airtight
     steps:
       - checkout
       - run:

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,5 @@
 {
   "extension": ["ts"],
   "spec": "tests/**/*.test.ts",
-  "require": "ts-node/register/transpile-only"
+  "require": ["ts-node/register/transpile-only", "./tests/eslint-test-bridge.cjs"]
 }

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,8 @@
 {
   "extension": ["ts"],
   "spec": "tests/**/*.test.ts",
-  "require": ["ts-node/register/transpile-only", "./tests/eslint-test-bridge.cjs"]
+  "require": [
+    "ts-node/register/transpile-only",
+    "./tests/eslint-test-bridge.cjs"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "scripts": {
     "prepare": "tsc",
-    "format": "prettier --write 'src/**/*.ts'",
+    "format": "prettier --write 'src/**/*.ts' 'tests/**/*.ts' '.*.json'",
     "lint": "eslint 'src/**/*.ts' 'tests/**/*.ts'",
     "test": "mocha"
   },
@@ -44,7 +44,7 @@
     "eslint-config-prettier": "^9",
     "mkdirp": "^1.0.4",
     "mocha": "^10.0.0",
-    "prettier": "~2.7.1",
+    "prettier": "~3.1.1",
     "tmp": "^0.2.1",
     "ts-node": "^10.7.0",
     "typescript": "~5.1"

--- a/package.json
+++ b/package.json
@@ -29,23 +29,24 @@
     ]
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^5.22.0",
+    "@typescript-eslint/utils": "^6",
     "tslib": "^2.1.0",
     "tsutils": "^3.21.0"
   },
   "devDependencies": {
     "@types/mkdirp": "^1.0.1",
-    "@types/mocha": "^9.1.1",
+    "@types/mocha": "^10",
     "@types/tmp": "^0.2.0",
-    "@typescript-eslint/eslint-plugin": "^5.22.0",
-    "@typescript-eslint/parser": "^5",
-    "eslint": "^7",
-    "eslint-config-prettier": "^8.5.0",
+    "@typescript-eslint/eslint-plugin": "^6",
+    "@typescript-eslint/parser": "^6",
+    "@typescript-eslint/rule-tester": "^6.18.0",
+    "eslint": "^8",
+    "eslint-config-prettier": "^9",
     "mkdirp": "^1.0.4",
     "mocha": "^10.0.0",
     "prettier": "~2.7.1",
     "tmp": "^0.2.1",
     "ts-node": "^10.7.0",
-    "typescript": "~4.8"
+    "typescript": "~5.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,20 @@
+import { TSESLint } from '@typescript-eslint/utils';
+
 import exportInline from './rules/export-inline';
+import { rule as importStyle } from './rules/import-style';
 import paramTypes from './rules/param-types';
 import returnAwait from './rules/return-await';
 import sequelizeComment from './rules/sequelize-comment';
 import unboundedConcurrency from './rules/unbounded-concurrency';
-import requireItlyConstant from './rules/require-itly-constant';
-import requireItlyEventSource from './rules/require-itly-event-source';
+import { rule as requireItlyConstant } from './rules/require-itly-constant';
+import { rule as requireItlyEventSource } from './rules/require-itly-event-source';
 
-export const rules = {
+export const rules: Record<
+  string,
+  TSESLint.RuleModule<string, unknown[], any>
+> = {
   'export-inline': exportInline,
+  'import-style': importStyle,
   'param-types': paramTypes,
   'return-await': returnAwait,
   'sequelize-comment': sequelizeComment,

--- a/src/rules/export-inline.ts
+++ b/src/rules/export-inline.ts
@@ -1,7 +1,5 @@
-import { TSESTree } from '@typescript-eslint/utils';
+import { TSESTree, TSESLint } from '@typescript-eslint/utils';
 import * as util from '../util/from-eslint-typescript';
-import { RuleContext } from '@typescript-eslint/utils/dist/ts-eslint';
-
 type Options = [{}];
 type MessageIds = 'mustBeInline' | 'unnecessaryEmptyExport';
 
@@ -10,7 +8,6 @@ export default util.createRule<Options, MessageIds>({
   meta: {
     docs: {
       description: '',
-      recommended: false,
       requiresTypeChecking: false,
     },
     fixable: 'code',
@@ -20,7 +17,7 @@ export default util.createRule<Options, MessageIds>({
       unnecessaryEmptyExport:
         '`export {}` is not necessary if there are other imports/exports',
     },
-    schema: [{}],
+    schema: [{} as any],
   },
   defaultOptions: [{}],
 
@@ -101,7 +98,7 @@ export default util.createRule<Options, MessageIds>({
 });
 
 function report(
-  context: RuleContext<MessageIds, Options>,
+  context: TSESLint.RuleContext<MessageIds, Options>,
   nodeOrToken: TSESTree.Node,
   spec: TSESTree.ExportSpecifier,
 ): void {

--- a/src/rules/import-style.ts
+++ b/src/rules/import-style.ts
@@ -17,7 +17,10 @@ export type Options = [
 type MessageIds = 'useRegularImport';
 
 // explicit typing to work around an apparent typescript compiler bug, please remove if it works for you
-export const rule: TSESLint.RuleModule<MessageIds, Options> = util.createRule<Options, MessageIds>({
+export const rule: TSESLint.RuleModule<MessageIds, Options> = util.createRule<
+  Options,
+  MessageIds
+>({
   name: 'import-style',
   meta: {
     docs: {

--- a/src/rules/import-style.ts
+++ b/src/rules/import-style.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/utils';
+import { TSESTree, TSESLint } from '@typescript-eslint/utils';
 import * as util from '../util/from-eslint-typescript';
 import path from 'path';
 import { importTarget } from '../util/node-imports';
@@ -16,12 +16,12 @@ export type Options = [
 ];
 type MessageIds = 'useRegularImport';
 
-export default util.createRule<Options, MessageIds>({
+// explicit typing to work around an apparent typescript compiler bug, please remove if it works for you
+export const rule: TSESLint.RuleModule<MessageIds, Options> = util.createRule<Options, MessageIds>({
   name: 'import-style',
   meta: {
     docs: {
       description: '',
-      recommended: false,
       requiresTypeChecking: false,
     },
     fixable: 'code',
@@ -29,7 +29,7 @@ export default util.createRule<Options, MessageIds>({
     messages: {
       useRegularImport: 'Modern import style available',
     },
-    schema: [{}],
+    schema: [{} as any],
   },
   defaultOptions: [{ requireToNamed: [] }],
 

--- a/src/rules/param-types.ts
+++ b/src/rules/param-types.ts
@@ -1,10 +1,6 @@
 import * as path from 'path';
-import { TSESTree } from '@typescript-eslint/utils';
+import { TSESTree, TSESLint } from '@typescript-eslint/utils';
 import * as util from '../util/from-eslint-typescript';
-import type {
-  ReportDescriptor,
-  RuleFix,
-} from '@typescript-eslint/utils/dist/ts-eslint';
 import { topLevel } from '../util';
 
 type Regex = string;
@@ -29,7 +25,6 @@ export default util.createRule<Options, MessageIds>({
   meta: {
     docs: {
       description: '',
-      recommended: false,
       requiresTypeChecking: false,
     },
     fixable: 'code',
@@ -75,7 +70,7 @@ export default util.createRule<Options, MessageIds>({
         for (const param of node.params) {
           if (param.type !== 'Identifier') continue;
 
-          if ('typeAnnotation' in param) {
+          if (param.typeAnnotation) {
             continue;
           }
 
@@ -84,12 +79,12 @@ export default util.createRule<Options, MessageIds>({
 
           const fixObj = fixes.find(([r]) => param.name.match(r));
 
-          let fix: ReportDescriptor<MessageIds>['fix'];
+          let fix: TSESLint.ReportDescriptor<MessageIds>['fix'];
           if (fixObj) {
             const [, [importFrom, type]] = fixObj;
             const importText = `import type { ${type} } from '${importFrom}';\n`;
             fix = (fixer) => {
-              const fixes: RuleFix[] = [];
+              const fixes: TSESLint.RuleFix[] = [];
               if (!imported.has(type)) {
                 imported.add(type);
                 fixes.push(fixer.insertTextBefore(topLevel(node), importText));

--- a/src/rules/require-itly-constant.ts
+++ b/src/rules/require-itly-constant.ts
@@ -1,8 +1,5 @@
+import { TSESTree, TSESLint } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES } from '@typescript-eslint/types';
-import {
-  ClassDeclaration,
-  PropertyDefinition,
-} from '@typescript-eslint/types/dist/generated/ast-spec';
 import * as util from '../util/from-eslint-typescript';
 import {
   classIsItlyEventImplementation,
@@ -12,100 +9,103 @@ import {
   ItlyRuleOptions,
 } from '../util/itly';
 
-export default util.createRule<ItlyRuleOptions, ItlyRuleMessageIds>({
-  name: 'require-itly-constant',
-  meta: {
-    type: 'problem',
-    docs: {
-      description: 'Enforces itly constant is set in Iteratively',
-      recommended: false,
-    },
-    schema: [{}],
-    messages: {
-      invalidFile:
-        'require-itly-constant should only be enabled for the generated Itly library',
-      missingRequiredItlyProperty: `{{ eventName }} is missing the Iteratively property group`,
-    },
-  },
-  defaultOptions: [{}],
-  create: function (context) {
-    function propertiesDeclarationContainsItlyConstant(
-      propertiesDeclaration: PropertyDefinition,
-    ) {
-      if (
-        propertiesDeclaration.typeAnnotation?.typeAnnotation.type ===
-        AST_NODE_TYPES.TSIntersectionType
-      ) {
-        const containsItlyLiteral =
-          propertiesDeclaration.typeAnnotation.typeAnnotation.types?.some(
-            (type) =>
-              type.type === AST_NODE_TYPES.TSTypeLiteral &&
-              type.members.some(
-                (member) =>
-                  member.type === AST_NODE_TYPES.TSPropertySignature &&
-                  member.key.type === AST_NODE_TYPES.Literal &&
-                  member.key.value === 'itly',
-              ),
-          );
-        return containsItlyLiteral;
-      }
-
-      if (
-        propertiesDeclaration.value?.type === AST_NODE_TYPES.ObjectExpression
-      ) {
-        return propertiesDeclaration.value.properties.some(
-          (property) =>
-            property.type === AST_NODE_TYPES.Property &&
-            property.key.type === AST_NODE_TYPES.Literal &&
-            property.key.value === 'itly',
-        );
-      }
-
-      return false;
-    }
-
-    function reportMissingItlyConstant(classDeclarationNode: ClassDeclaration) {
-      context.report({
-        node: classDeclarationNode,
-        messageId: 'missingRequiredItlyProperty',
-        data: { eventName: classDeclarationNode.id?.name },
-      });
-    }
-
-    return {
-      ClassDeclaration(classDeclarationNode) {
-        if (!isItlyFile(context)) {
-          context.report({
-            node: classDeclarationNode,
-            messageId: 'invalidFile',
-          });
-          return;
-        }
-
-        if (!classIsItlyEventImplementation(classDeclarationNode)) {
-          return;
-        }
-
-        const itlyPropertiesDeclaration = getItlyPropertiesDeclaration(
-          classDeclarationNode.body,
-        );
-
-        if (
-          !itlyPropertiesDeclaration ||
-          itlyPropertiesDeclaration.type !== AST_NODE_TYPES.PropertyDefinition
-        ) {
-          reportMissingItlyConstant(classDeclarationNode);
-          return;
-        }
-
-        if (
-          propertiesDeclarationContainsItlyConstant(itlyPropertiesDeclaration)
-        ) {
-          return;
-        }
-
-        reportMissingItlyConstant(classDeclarationNode);
+// explicit typing to work around an apparent typescript compiler bug, please remove if it works for you
+export const rule: TSESLint.RuleModule<ItlyRuleMessageIds, ItlyRuleOptions> =
+  util.createRule<ItlyRuleOptions, ItlyRuleMessageIds>({
+    name: 'require-itly-constant',
+    meta: {
+      type: 'problem',
+      docs: {
+        description: 'Enforces itly constant is set in Iteratively',
       },
-    };
-  },
-});
+      schema: [{} as any],
+      messages: {
+        invalidFile:
+          'require-itly-constant should only be enabled for the generated Itly library',
+        missingRequiredItlyProperty: `{{ eventName }} is missing the Iteratively property group`,
+      },
+    },
+    defaultOptions: [{}],
+    create: function (context) {
+      function propertiesDeclarationContainsItlyConstant(
+        propertiesDeclaration: TSESTree.PropertyDefinition,
+      ) {
+        if (
+          propertiesDeclaration.typeAnnotation?.typeAnnotation.type ===
+          AST_NODE_TYPES.TSIntersectionType
+        ) {
+          const containsItlyLiteral =
+            propertiesDeclaration.typeAnnotation.typeAnnotation.types?.some(
+              (type) =>
+                type.type === AST_NODE_TYPES.TSTypeLiteral &&
+                type.members.some(
+                  (member) =>
+                    member.type === AST_NODE_TYPES.TSPropertySignature &&
+                    member.key.type === AST_NODE_TYPES.Literal &&
+                    member.key.value === 'itly',
+                ),
+            );
+          return containsItlyLiteral;
+        }
+
+        if (
+          propertiesDeclaration.value?.type === AST_NODE_TYPES.ObjectExpression
+        ) {
+          return propertiesDeclaration.value.properties.some(
+            (property) =>
+              property.type === AST_NODE_TYPES.Property &&
+              property.key.type === AST_NODE_TYPES.Literal &&
+              property.key.value === 'itly',
+          );
+        }
+
+        return false;
+      }
+
+      function reportMissingItlyConstant(
+        classDeclarationNode: TSESTree.ClassDeclaration,
+      ) {
+        context.report({
+          node: classDeclarationNode,
+          messageId: 'missingRequiredItlyProperty',
+          data: { eventName: classDeclarationNode.id?.name },
+        });
+      }
+
+      return {
+        ClassDeclaration(classDeclarationNode) {
+          if (!isItlyFile(context)) {
+            context.report({
+              node: classDeclarationNode,
+              messageId: 'invalidFile',
+            });
+            return;
+          }
+
+          if (!classIsItlyEventImplementation(classDeclarationNode)) {
+            return;
+          }
+
+          const itlyPropertiesDeclaration = getItlyPropertiesDeclaration(
+            classDeclarationNode.body,
+          );
+
+          if (
+            !itlyPropertiesDeclaration ||
+            itlyPropertiesDeclaration.type !== AST_NODE_TYPES.PropertyDefinition
+          ) {
+            reportMissingItlyConstant(classDeclarationNode);
+            return;
+          }
+
+          if (
+            propertiesDeclarationContainsItlyConstant(itlyPropertiesDeclaration)
+          ) {
+            return;
+          }
+
+          reportMissingItlyConstant(classDeclarationNode);
+        },
+      };
+    },
+  });

--- a/src/rules/require-itly-event-source.ts
+++ b/src/rules/require-itly-event-source.ts
@@ -1,8 +1,5 @@
 import { AST_NODE_TYPES } from '@typescript-eslint/types';
-import {
-  ClassDeclaration,
-  PropertyDefinition,
-} from '@typescript-eslint/types/dist/generated/ast-spec';
+import { TSESTree, TSESLint } from '@typescript-eslint/utils';
 import * as util from '../util/from-eslint-typescript';
 import {
   classIsItlyEventImplementation,
@@ -15,15 +12,15 @@ import {
   ItlyRuleOptions,
 } from '../util/itly';
 
-export default util.createRule<ItlyRuleOptions, ItlyRuleMessageIds>({
+// explicit typing to work around an apparent typescript compiler bug, please remove if it works for you
+export const rule: TSESLint.RuleModule<ItlyRuleMessageIds, ItlyRuleOptions> =  util.createRule<ItlyRuleOptions, ItlyRuleMessageIds>({
   name: 'require-itly-event-source',
   meta: {
     type: 'problem',
     docs: {
       description: 'Enforces itly eventSource is set in Iteratively',
-      recommended: false,
     },
-    schema: [{}],
+    schema: [{} as any],
     messages: {
       invalidFile:
         'require-itly-event-source should only be enabled for the generated Itly library',
@@ -33,7 +30,7 @@ export default util.createRule<ItlyRuleOptions, ItlyRuleMessageIds>({
   defaultOptions: [{}],
   create: function (context) {
     function propertiesDeclarationContainsEventSourceConstant(
-      propertiesDeclaration: PropertyDefinition,
+      propertiesDeclaration: TSESTree.PropertyDefinition,
     ) {
       if (
         propertiesDeclaration.typeAnnotation?.typeAnnotation.type ===
@@ -68,7 +65,7 @@ export default util.createRule<ItlyRuleOptions, ItlyRuleMessageIds>({
     }
 
     function getPropertiesInterfaceName(
-      itlyPropertiesDeclaration: PropertyDefinition,
+      itlyPropertiesDeclaration: TSESTree.PropertyDefinition,
     ) {
       const implementedProperties = getImplementedProperties(
         itlyPropertiesDeclaration,
@@ -84,7 +81,7 @@ export default util.createRule<ItlyRuleOptions, ItlyRuleMessageIds>({
     }
 
     function propertiesInterfaceContainsEventSource(
-      itlyPropertiesDeclaration: PropertyDefinition,
+      itlyPropertiesDeclaration: TSESTree.PropertyDefinition,
     ) {
       const interfaceName = getPropertiesInterfaceName(
         itlyPropertiesDeclaration,
@@ -115,7 +112,9 @@ export default util.createRule<ItlyRuleOptions, ItlyRuleMessageIds>({
       );
     }
 
-    function reportMissingItlyConstant(classDeclarationNode: ClassDeclaration) {
+    function reportMissingItlyConstant(
+      classDeclarationNode: TSESTree.ClassDeclaration,
+    ) {
       context.report({
         node: classDeclarationNode,
         messageId: 'missingRequiredItlyProperty',

--- a/src/rules/require-itly-event-source.ts
+++ b/src/rules/require-itly-event-source.ts
@@ -13,158 +13,161 @@ import {
 } from '../util/itly';
 
 // explicit typing to work around an apparent typescript compiler bug, please remove if it works for you
-export const rule: TSESLint.RuleModule<ItlyRuleMessageIds, ItlyRuleOptions> =  util.createRule<ItlyRuleOptions, ItlyRuleMessageIds>({
-  name: 'require-itly-event-source',
-  meta: {
-    type: 'problem',
-    docs: {
-      description: 'Enforces itly eventSource is set in Iteratively',
-    },
-    schema: [{} as any],
-    messages: {
-      invalidFile:
-        'require-itly-event-source should only be enabled for the generated Itly library',
-      missingRequiredItlyProperty: `{{ eventName }} is missing the Event Source property group, please update the Event at data.amplitude.com/snyk`,
-    },
-  },
-  defaultOptions: [{}],
-  create: function (context) {
-    function propertiesDeclarationContainsEventSourceConstant(
-      propertiesDeclaration: TSESTree.PropertyDefinition,
-    ) {
-      if (
-        propertiesDeclaration.typeAnnotation?.typeAnnotation.type ===
-        AST_NODE_TYPES.TSIntersectionType
-      ) {
-        const containsItlyLiteral =
-          propertiesDeclaration.typeAnnotation.typeAnnotation.types?.some(
-            (type) =>
-              type.type === AST_NODE_TYPES.TSTypeLiteral &&
-              type.members.some(
-                (member) =>
-                  member.type === AST_NODE_TYPES.TSPropertySignature &&
-                  member.key.type === AST_NODE_TYPES.Literal &&
-                  member.key.value === 'eventSource',
-              ),
-          );
-        return containsItlyLiteral;
-      }
-
-      if (
-        propertiesDeclaration.value?.type === AST_NODE_TYPES.ObjectExpression
-      ) {
-        return propertiesDeclaration.value.properties.some(
-          (property) =>
-            property.type === AST_NODE_TYPES.Property &&
-            property.key.type === AST_NODE_TYPES.Literal &&
-            property.key.value === 'eventSource',
-        );
-      }
-
-      return false;
-    }
-
-    function getPropertiesInterfaceName(
-      itlyPropertiesDeclaration: TSESTree.PropertyDefinition,
-    ) {
-      const implementedProperties = getImplementedProperties(
-        itlyPropertiesDeclaration,
-      );
-
-      if (!implementedProperties) {
-        return;
-      }
-
-      return implementedProperties.typeName.type === AST_NODE_TYPES.Identifier
-        ? implementedProperties.typeName.name
-        : undefined;
-    }
-
-    function propertiesInterfaceContainsEventSource(
-      itlyPropertiesDeclaration: TSESTree.PropertyDefinition,
-    ) {
-      const interfaceName = getPropertiesInterfaceName(
-        itlyPropertiesDeclaration,
-      );
-
-      if (!interfaceName) {
-        return false;
-      }
-      const program = getProgram(itlyPropertiesDeclaration);
-
-      if (!program) {
-        return false;
-      }
-      const interfaceDeclaration = getInterfaceDeclarationFromProgram(
-        program,
-        interfaceName,
-      );
-
-      if (!interfaceDeclaration) {
-        return false;
-      }
-
-      return interfaceDeclaration.body.body.some(
-        (node) =>
-          node.type === AST_NODE_TYPES.TSPropertySignature &&
-          node.key.type === AST_NODE_TYPES.Identifier &&
-          node.key.name === 'eventSource',
-      );
-    }
-
-    function reportMissingItlyConstant(
-      classDeclarationNode: TSESTree.ClassDeclaration,
-    ) {
-      context.report({
-        node: classDeclarationNode,
-        messageId: 'missingRequiredItlyProperty',
-        data: { eventName: classDeclarationNode.id?.name },
-      });
-    }
-
-    return {
-      ClassDeclaration(classDeclarationNode) {
-        if (!isItlyFile(context)) {
-          context.report({
-            node: classDeclarationNode,
-            messageId: 'invalidFile',
-          });
-          return;
-        }
-
-        if (!classIsItlyEventImplementation(classDeclarationNode)) {
-          return;
-        }
-
-        const itlyPropertiesDeclaration = getItlyPropertiesDeclaration(
-          classDeclarationNode.body,
-        );
-
-        if (
-          !itlyPropertiesDeclaration ||
-          itlyPropertiesDeclaration.type !== AST_NODE_TYPES.PropertyDefinition
-        ) {
-          reportMissingItlyConstant(classDeclarationNode);
-          return;
-        }
-
-        // eventSource may show up as a constant (like itly: true)...
-        if (
-          propertiesDeclarationContainsEventSourceConstant(
-            itlyPropertiesDeclaration,
-          )
-        ) {
-          return;
-        }
-
-        // ...or it may be contained in the Event's properties interface
-        if (propertiesInterfaceContainsEventSource(itlyPropertiesDeclaration)) {
-          return;
-        }
-
-        // eventSource was not found in any of the expected places
-        reportMissingItlyConstant(classDeclarationNode);
+export const rule: TSESLint.RuleModule<ItlyRuleMessageIds, ItlyRuleOptions> =
+  util.createRule<ItlyRuleOptions, ItlyRuleMessageIds>({
+    name: 'require-itly-event-source',
+    meta: {
+      type: 'problem',
+      docs: {
+        description: 'Enforces itly eventSource is set in Iteratively',
       },
-    };
-  },
-});
+      schema: [{} as any],
+      messages: {
+        invalidFile:
+          'require-itly-event-source should only be enabled for the generated Itly library',
+        missingRequiredItlyProperty: `{{ eventName }} is missing the Event Source property group, please update the Event at data.amplitude.com/snyk`,
+      },
+    },
+    defaultOptions: [{}],
+    create: function (context) {
+      function propertiesDeclarationContainsEventSourceConstant(
+        propertiesDeclaration: TSESTree.PropertyDefinition,
+      ) {
+        if (
+          propertiesDeclaration.typeAnnotation?.typeAnnotation.type ===
+          AST_NODE_TYPES.TSIntersectionType
+        ) {
+          const containsItlyLiteral =
+            propertiesDeclaration.typeAnnotation.typeAnnotation.types?.some(
+              (type) =>
+                type.type === AST_NODE_TYPES.TSTypeLiteral &&
+                type.members.some(
+                  (member) =>
+                    member.type === AST_NODE_TYPES.TSPropertySignature &&
+                    member.key.type === AST_NODE_TYPES.Literal &&
+                    member.key.value === 'eventSource',
+                ),
+            );
+          return containsItlyLiteral;
+        }
+
+        if (
+          propertiesDeclaration.value?.type === AST_NODE_TYPES.ObjectExpression
+        ) {
+          return propertiesDeclaration.value.properties.some(
+            (property) =>
+              property.type === AST_NODE_TYPES.Property &&
+              property.key.type === AST_NODE_TYPES.Literal &&
+              property.key.value === 'eventSource',
+          );
+        }
+
+        return false;
+      }
+
+      function getPropertiesInterfaceName(
+        itlyPropertiesDeclaration: TSESTree.PropertyDefinition,
+      ) {
+        const implementedProperties = getImplementedProperties(
+          itlyPropertiesDeclaration,
+        );
+
+        if (!implementedProperties) {
+          return;
+        }
+
+        return implementedProperties.typeName.type === AST_NODE_TYPES.Identifier
+          ? implementedProperties.typeName.name
+          : undefined;
+      }
+
+      function propertiesInterfaceContainsEventSource(
+        itlyPropertiesDeclaration: TSESTree.PropertyDefinition,
+      ) {
+        const interfaceName = getPropertiesInterfaceName(
+          itlyPropertiesDeclaration,
+        );
+
+        if (!interfaceName) {
+          return false;
+        }
+        const program = getProgram(itlyPropertiesDeclaration);
+
+        if (!program) {
+          return false;
+        }
+        const interfaceDeclaration = getInterfaceDeclarationFromProgram(
+          program,
+          interfaceName,
+        );
+
+        if (!interfaceDeclaration) {
+          return false;
+        }
+
+        return interfaceDeclaration.body.body.some(
+          (node) =>
+            node.type === AST_NODE_TYPES.TSPropertySignature &&
+            node.key.type === AST_NODE_TYPES.Identifier &&
+            node.key.name === 'eventSource',
+        );
+      }
+
+      function reportMissingItlyConstant(
+        classDeclarationNode: TSESTree.ClassDeclaration,
+      ) {
+        context.report({
+          node: classDeclarationNode,
+          messageId: 'missingRequiredItlyProperty',
+          data: { eventName: classDeclarationNode.id?.name },
+        });
+      }
+
+      return {
+        ClassDeclaration(classDeclarationNode) {
+          if (!isItlyFile(context)) {
+            context.report({
+              node: classDeclarationNode,
+              messageId: 'invalidFile',
+            });
+            return;
+          }
+
+          if (!classIsItlyEventImplementation(classDeclarationNode)) {
+            return;
+          }
+
+          const itlyPropertiesDeclaration = getItlyPropertiesDeclaration(
+            classDeclarationNode.body,
+          );
+
+          if (
+            !itlyPropertiesDeclaration ||
+            itlyPropertiesDeclaration.type !== AST_NODE_TYPES.PropertyDefinition
+          ) {
+            reportMissingItlyConstant(classDeclarationNode);
+            return;
+          }
+
+          // eventSource may show up as a constant (like itly: true)...
+          if (
+            propertiesDeclarationContainsEventSourceConstant(
+              itlyPropertiesDeclaration,
+            )
+          ) {
+            return;
+          }
+
+          // ...or it may be contained in the Event's properties interface
+          if (
+            propertiesInterfaceContainsEventSource(itlyPropertiesDeclaration)
+          ) {
+            return;
+          }
+
+          // eventSource was not found in any of the expected places
+          reportMissingItlyConstant(classDeclarationNode);
+        },
+      };
+    },
+  });

--- a/src/rules/return-await.ts
+++ b/src/rules/return-await.ts
@@ -38,12 +38,12 @@ export default util.createRule<Options, MessageIds>({
   meta: {
     docs: {
       description: 'Enforces consistent returning of awaited values',
-      recommended: false,
       requiresTypeChecking: true,
       extendsBaseRule: 'no-return-await',
     },
     fixable: 'code',
     type: 'problem',
+    hasSuggestions: true,
     messages: {
       nonPromiseAwait:
         'Returning an awaited value that is not a promise is not allowed.',
@@ -63,7 +63,7 @@ export default util.createRule<Options, MessageIds>({
           neverRemove: { type: 'boolean' },
         },
       },
-    ],
+    ] as any,
   },
   defaultOptions: [
     'in-try-catch',

--- a/src/rules/sequelize-comment.ts
+++ b/src/rules/sequelize-comment.ts
@@ -1,6 +1,5 @@
-import { TSESTree } from '@typescript-eslint/utils';
+import { TSESTree, TSESLint } from '@typescript-eslint/utils';
 import * as util from '../util/from-eslint-typescript';
-import { ReportDescriptor } from '@typescript-eslint/utils/dist/ts-eslint';
 
 type Options = [{}];
 type MessageIds = 'requiresComment';
@@ -10,7 +9,6 @@ export default util.createRule<Options, MessageIds>({
   meta: {
     docs: {
       description: '',
-      recommended: false,
       requiresTypeChecking: false,
     },
     fixable: 'code',
@@ -18,7 +16,7 @@ export default util.createRule<Options, MessageIds>({
     messages: {
       requiresComment: 'The `comment` property is required',
     },
-    schema: [{}],
+    schema: [{} as any],
   },
   defaultOptions: [{}],
 
@@ -45,7 +43,7 @@ export default util.createRule<Options, MessageIds>({
         // literally just {}
         const trulyEmptyBlock = 2 === arg.range[1] - arg.range[0];
 
-        let fix: ReportDescriptor<MessageIds>['fix'] = undefined;
+        let fix: TSESLint.ReportDescriptor<MessageIds>['fix'] = undefined;
         if (funcName && (hasAnyProperties || trulyEmptyBlock)) {
           fix = (fixer) => {
             const pathEnd = context

--- a/src/rules/unbounded-concurrency.ts
+++ b/src/rules/unbounded-concurrency.ts
@@ -1,9 +1,5 @@
-import { TSESTree } from '@typescript-eslint/utils';
+import { TSESTree, TSESLint } from '@typescript-eslint/utils';
 import * as util from '../util/from-eslint-typescript';
-import type {
-  ReportDescriptor,
-  RuleFix,
-} from '@typescript-eslint/utils/dist/ts-eslint';
 import { topLevel } from '../util';
 
 type Options = [{}];
@@ -14,7 +10,6 @@ export default util.createRule<Options, MessageIds>({
   meta: {
     docs: {
       description: '',
-      recommended: false,
       requiresTypeChecking: false,
     },
     fixable: 'code',
@@ -88,8 +83,8 @@ export default util.createRule<Options, MessageIds>({
             let func = imported.values().next().value;
             const obj = sourceCode.getText(arg.callee.object);
             const mapper = sourceCode.getText(arg.arguments[0]);
-            const fix: ReportDescriptor<MessageIds>['fix'] = (fixer) => {
-              const fixes: RuleFix[] = [];
+            const fix: TSESLint.ReportDescriptor<MessageIds>['fix'] = (fixer) => {
+              const fixes: TSESLint.RuleFix[] = [];
               if (!func) {
                 func = 'pMap';
                 imported.add(func);
@@ -120,7 +115,7 @@ export default util.createRule<Options, MessageIds>({
             if (!imported.has(node.callee.name)) return;
 
             if (2 === node.arguments.length) {
-              const fix: ReportDescriptor<MessageIds>['fix'] = (fixer) =>
+              const fix: TSESLint.ReportDescriptor<MessageIds>['fix'] = (fixer) =>
                 fixer.insertTextAfter(
                   node.arguments[1],
                   ', { concurrency: 6 }',

--- a/src/rules/unbounded-concurrency.ts
+++ b/src/rules/unbounded-concurrency.ts
@@ -83,7 +83,9 @@ export default util.createRule<Options, MessageIds>({
             let func = imported.values().next().value;
             const obj = sourceCode.getText(arg.callee.object);
             const mapper = sourceCode.getText(arg.arguments[0]);
-            const fix: TSESLint.ReportDescriptor<MessageIds>['fix'] = (fixer) => {
+            const fix: TSESLint.ReportDescriptor<MessageIds>['fix'] = (
+              fixer,
+            ) => {
               const fixes: TSESLint.RuleFix[] = [];
               if (!func) {
                 func = 'pMap';
@@ -115,7 +117,9 @@ export default util.createRule<Options, MessageIds>({
             if (!imported.has(node.callee.name)) return;
 
             if (2 === node.arguments.length) {
-              const fix: TSESLint.ReportDescriptor<MessageIds>['fix'] = (fixer) =>
+              const fix: TSESLint.ReportDescriptor<MessageIds>['fix'] = (
+                fixer,
+              ) =>
                 fixer.insertTextAfter(
                   node.arguments[1],
                   ', { concurrency: 6 }',

--- a/src/util/from-eslint-typescript.ts
+++ b/src/util/from-eslint-typescript.ts
@@ -46,8 +46,8 @@ export function isTypeFlagSet(
 /**
  * Gets all of the type flags in a type, iterating through unions automatically
  */
-export function getTypeFlags(type: ts.Type): ts.TypeFlags {
-  let flags: ts.TypeFlags = 0;
+export function getTypeFlags(type: ts.Type): ts.TypeFlags | 0 {
+  let flags: ts.TypeFlags | 0 = 0;
   for (const t of unionTypeParts(type)) {
     flags |= t.flags;
   }

--- a/src/util/itly.ts
+++ b/src/util/itly.ts
@@ -1,15 +1,6 @@
-import { RuleContext } from '@typescript-eslint/utils/dist/ts-eslint';
+import { RuleContext } from '@typescript-eslint/utils/ts-eslint';
 import { AST_NODE_TYPES } from '@typescript-eslint/types';
-import {
-  ClassBody,
-  ClassDeclaration,
-  PropertyDefinition,
-  TSTypeReference,
-  TSInterfaceDeclaration,
-  Program,
-  Node,
-  ExportNamedDeclaration,
-} from '@typescript-eslint/types/dist/generated/ast-spec';
+import { TSESTree } from '@typescript-eslint/utils';
 
 export type ItlyRuleOptions = [{}];
 export type ItlyRuleMessageIds = 'invalidFile' | 'missingRequiredItlyProperty';
@@ -21,7 +12,7 @@ export function isItlyFile(
 }
 
 export function classIsItlyEventImplementation(
-  classDeclaration: ClassDeclaration,
+  classDeclaration: TSESTree.ClassDeclaration,
 ) {
   return classDeclaration.implements?.find(
     (implementsNode) =>
@@ -30,7 +21,7 @@ export function classIsItlyEventImplementation(
   );
 }
 
-export function getItlyPropertiesDeclaration(classBody: ClassBody) {
+export function getItlyPropertiesDeclaration(classBody: TSESTree.ClassBody) {
   return classBody.body.find(
     (classProperty) =>
       classProperty.type === AST_NODE_TYPES.PropertyDefinition &&
@@ -40,18 +31,18 @@ export function getItlyPropertiesDeclaration(classBody: ClassBody) {
 }
 
 export function getImplementedProperties(
-  classElement: PropertyDefinition,
-): TSTypeReference | undefined {
+  classElement: TSESTree.PropertyDefinition,
+): TSESTree.TSTypeReference | undefined {
   const typeAnnotation = classElement.typeAnnotation?.typeAnnotation;
   if (typeAnnotation?.type === AST_NODE_TYPES.TSIntersectionType) {
     return typeAnnotation.types.find(
       (type) => type.type === AST_NODE_TYPES.TSTypeReference,
-    ) as TSTypeReference | undefined;
+    ) as TSESTree.TSTypeReference | undefined;
   }
   return;
 }
 
-export function getProgram(node: Node) {
+export function getProgram(node: TSESTree.Node) {
   let parent = node.parent;
   while (parent && parent.type !== AST_NODE_TYPES.Program) {
     parent = parent.parent;
@@ -60,14 +51,16 @@ export function getProgram(node: Node) {
 }
 
 export function getInterfaceDeclarationFromProgram(
-  program: Program,
+  program: TSESTree.Program,
   name: string,
-): TSInterfaceDeclaration | undefined {
+): TSESTree.TSInterfaceDeclaration | undefined {
   const declaration = program.body.find(
     (node) =>
       node.type === AST_NODE_TYPES.ExportNamedDeclaration &&
       node.declaration?.type === AST_NODE_TYPES.TSInterfaceDeclaration &&
       node.declaration.id.name === name,
-  ) as ExportNamedDeclaration | undefined;
-  return declaration?.declaration as TSInterfaceDeclaration | undefined;
+  ) as TSESTree.ExportNamedDeclaration | undefined;
+  return declaration?.declaration as
+    | TSESTree.TSInterfaceDeclaration
+    | undefined;
 }

--- a/tests/eslint-test-bridge.cjs
+++ b/tests/eslint-test-bridge.cjs
@@ -1,0 +1,4 @@
+const mocha = require('mocha');
+const { RuleTester } = require('@typescript-eslint/rule-tester');
+
+RuleTester.afterAll = mocha.after;

--- a/tests/rules/export-inline.test.ts
+++ b/tests/rules/export-inline.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import rule from '../../src/rules/export-inline';
-import { RuleTester } from '@typescript-eslint/utils/dist/eslint-utils';
+import { RuleTester } from '@typescript-eslint/rule-tester';
 
 const ruleTester = new RuleTester({
   parserOptions: {

--- a/tests/rules/export-inline.test.ts
+++ b/tests/rules/export-inline.test.ts
@@ -142,5 +142,5 @@ ruleTester.run('export-inline', rule, {
         },
       ],
     },
-  ]
+  ],
 });

--- a/tests/rules/import-style.test.ts
+++ b/tests/rules/import-style.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
-import rule from '../../src/rules/import-style';
+import { rule } from '../../src/rules/import-style';
 import type { Options } from '../../src/rules/import-style';
-import { RuleTester } from '@typescript-eslint/utils/dist/eslint-utils';
+import { RuleTester } from '@typescript-eslint/rule-tester';
 
 const ruleTester = new RuleTester({
   parserOptions: {

--- a/tests/rules/import-style.test.ts
+++ b/tests/rules/import-style.test.ts
@@ -12,10 +12,22 @@ const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
 
-const manyTransforms: Options = [{
-  wildNsToRequire: [ { path: './bar' }, { path: 'baz' } , { local: 'foo', path: './bar' }, { local: 'foo', path: 'baz' } ],
-  requireToNamed: [ { path: './bar' }, { path: 'baz' } , { local: 'foo', path: './bar' }, { local: 'foo', path: 'baz' } ],
-}];
+const manyTransforms: Options = [
+  {
+    wildNsToRequire: [
+      { path: './bar' },
+      { path: 'baz' },
+      { local: 'foo', path: './bar' },
+      { local: 'foo', path: 'baz' },
+    ],
+    requireToNamed: [
+      { path: './bar' },
+      { path: 'baz' },
+      { local: 'foo', path: './bar' },
+      { local: 'foo', path: 'baz' },
+    ],
+  },
+];
 
 ruleTester.run('import-style', rule, {
   valid: [
@@ -34,9 +46,11 @@ ruleTester.run('import-style', rule, {
     {
       code: `import foo = require('./foo/bar');`,
       output: `import { foo } from './foo/bar';`,
-      options: [{
-        requireToNamed: [{local: 'foo', path: './foo/bar'}],
-      }],
+      options: [
+        {
+          requireToNamed: [{ local: 'foo', path: './foo/bar' }],
+        },
+      ],
       errors: [
         {
           line: 1,
@@ -60,9 +74,11 @@ ruleTester.run('import-style', rule, {
     {
       code: `import * as foo from 'potato';`,
       output: `import foo = require('potato');`,
-      options: [{
-        wildNsToRequire: [{path: 'potato'}],
-      }],
+      options: [
+        {
+          wildNsToRequire: [{ path: 'potato' }],
+        },
+      ],
       errors: [
         {
           line: 1,
@@ -70,5 +86,5 @@ ruleTester.run('import-style', rule, {
         },
       ],
     },
-  ]
+  ],
 });

--- a/tests/rules/param-types.test.ts
+++ b/tests/rules/param-types.test.ts
@@ -25,7 +25,7 @@ ruleTester.run('param-types', rule, {
   ],
   invalid: [
     {
-      options: [{required: [".*"], fixes: {"foo": ["./lib/types", "Foo"]}}],
+      options: [{ required: ['.*'], fixes: { foo: ['./lib/types', 'Foo'] } }],
       code: `function test(foo) {}`,
       output: `import type { Foo } from '../lib/types';
 function test(foo: Foo) {}`,
@@ -37,7 +37,7 @@ function test(foo: Foo) {}`,
       ],
     },
     {
-      options: [{required: [".*"], fixes: {"foo": ["./lib/types", "Foo"]}}],
+      options: [{ required: ['.*'], fixes: { foo: ['./lib/types', 'Foo'] } }],
       code: `import type { Foo } from '../lib/types';
 function test(foo) {}`,
       output: `import type { Foo } from '../lib/types';
@@ -50,7 +50,7 @@ function test(foo: Foo) {}`,
       ],
     },
     {
-      options: [{required: [".*"], fixes: {"foo": ["./lib/types", "Foo"]}}],
+      options: [{ required: ['.*'], fixes: { foo: ['./lib/types', 'Foo'] } }],
       code: `function test(foo) {}
 function two(foo) {}
 function three(foo) {}
@@ -64,17 +64,19 @@ function three(foo: Foo) {}
         {
           line: 1,
           messageId: 'mustBeTyped',
-        },        {
+        },
+        {
           line: 2,
           messageId: 'mustBeTyped',
-        },        {
+        },
+        {
           line: 3,
           messageId: 'mustBeTyped',
         },
       ],
     },
     {
-      options: [{required: [".*"], fixes: {"foo": ["lib-foo", "Foo"]}}],
+      options: [{ required: ['.*'], fixes: { foo: ['lib-foo', 'Foo'] } }],
       code: `function test(foo) {}`,
       output: `import type { Foo } from 'lib-foo';
 function test(foo: Foo) {}`,
@@ -85,5 +87,5 @@ function test(foo: Foo) {}`,
         },
       ],
     },
-  ]
+  ],
 });

--- a/tests/rules/param-types.test.ts
+++ b/tests/rules/param-types.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import rule from '../../src/rules/param-types';
-import { RuleTester } from '@typescript-eslint/utils/dist/eslint-utils';
+import { RuleTester } from '@typescript-eslint/rule-tester';
 
 const ruleTester = new RuleTester({
   parserOptions: {

--- a/tests/rules/return-await.test.ts
+++ b/tests/rules/return-await.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import rule from '../../src/rules/return-await';
-import { RuleTester } from '@typescript-eslint/utils/dist/eslint-utils';
+import { RuleTester } from '@typescript-eslint/rule-tester';
 
 const ruleTester = new RuleTester({
   parserOptions: {

--- a/tests/rules/sequelize-comment.test.ts
+++ b/tests/rules/sequelize-comment.test.ts
@@ -12,11 +12,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('sequelize-comment', rule, {
-  valid: [
-    `findAll({})`,
-    `foo.findAll(2)`,
-    `foo.findAll({ comment: 'hello' })`,
-  ],
+  valid: [`findAll({})`, `foo.findAll(2)`, `foo.findAll({ comment: 'hello' })`],
   invalid: [
     {
       code: `function night() { return foo.findAll({ where: {} }) }`,
@@ -85,6 +81,6 @@ ruleTester.run('sequelize-comment', rule, {
           messageId: 'requiresComment',
         },
       ],
-    }
-  ]
+    },
+  ],
 });

--- a/tests/rules/sequelize-comment.test.ts
+++ b/tests/rules/sequelize-comment.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import rule from '../../src/rules/sequelize-comment';
-import { RuleTester } from '@typescript-eslint/utils/dist/eslint-utils';
+import { RuleTester } from '@typescript-eslint/rule-tester';
 
 const ruleTester = new RuleTester({
   parserOptions: {

--- a/tests/rules/unbounded-concurrency.test.ts
+++ b/tests/rules/unbounded-concurrency.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import rule from '../../src/rules/unbounded-concurrency';
-import { RuleTester } from '@typescript-eslint/utils/dist/eslint-utils';
+import { RuleTester } from '@typescript-eslint/rule-tester';
 
 const ruleTester = new RuleTester({
   parserOptions: {

--- a/tests/rules/unbounded-concurrency.test.ts
+++ b/tests/rules/unbounded-concurrency.test.ts
@@ -85,5 +85,5 @@ await pMap(unknownVar, async (v) => v, { concurrency: 6 });`,
         },
       ],
     },
-  ]
+  ],
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "./dist",
     "target": "es2017",
     "lib": ["es2017"],
-    "module": "commonjs",
+    "module": "node16",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "declaration": true,
@@ -12,7 +12,7 @@
     "skipLibCheck": true,
     "strict": true,
     "importHelpers": true,
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "noUnusedLocals": true,
     "noImplicitReturns": true
   },


### PR DESCRIPTION
Upgrade `eslint` to 8, and fix many of the compile errors this introduces; leaving working, widely unedited tests, and assume that's fine.

Breaking change: different eslint version, and hence different supported typescript compiler ranges etc.

Not integration tested.